### PR TITLE
Upgrade dependencies to be compatible with rosbridge_suite 0.11.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+            http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	
 
 	<groupId>edu.wpi.rail</groupId>
 	<artifactId>jrosbridge</artifactId>
-	<version>0.2.1-SNAPSHOT</version>
-	<packaging>jar</packaging>
-
+	<version>0.2.2-SNAPSHOT</version>
+	
+	<properties>
+		<java.version>1.8</java.version>
+		<spring-cloud.version>Hoxton.SR3</spring-cloud.version>
+	</properties>
 	<name>jrosbridge</name>
 	<url>https://github.com/rctoris/jrosbridge</url>
 	<licenses>
@@ -24,11 +31,6 @@
 		<url>https://github.com/rctoris/jrosbridge/issues</url>
 	</issueManagement>
 
-	<properties>
-		<jdk.version>1.7</jdk.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-
 	<scm>
 		<connection>scm:git:git://github.com/rctoris/jrosbridge.git</connection>
 		<developerConnection>scm:git:git@github.com:rctoris/jrosbridge.git</developerConnection>
@@ -45,12 +47,19 @@
 		<dependency>
 			<groupId>org.glassfish.tyrus</groupId>
 			<artifactId>tyrus-client</artifactId>
-			<version>1.2.1</version>
+			<version>1.17</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.glassfish.tyrus</groupId>
-			<artifactId>tyrus-container-grizzly</artifactId>
-			<version>1.2.1</version>
+			<artifactId>tyrus-container-grizzly-client</artifactId>
+			<version>1.17</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish.tyrus</groupId>
+			<artifactId>tyrus-server</artifactId>
+			<version>1.17</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -58,12 +67,8 @@
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.glassfish.tyrus</groupId>
-			<artifactId>tyrus-server</artifactId>
-			<version>1.2.1</version>
-			<scope>test</scope>
-		</dependency>
+
+
 	</dependencies>
 
 	<build>
@@ -74,8 +79,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.1</version>
 					<configuration>
-						<source>${jdk.version}</source>
-						<target>${jdk.version}</target>
+						<source>${java.version}</source>
+						<target>${java.version}</target>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -83,6 +88,7 @@
 					<artifactId>maven-release-plugin</artifactId>
 					<version>2.4.2</version>
 					<configuration>
+						<!--suppress UnresolvedMavenProperty -->
 						<arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
 					</configuration>
 				</plugin>
@@ -143,7 +149,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.4</version>
+						<version>1.6</version>
 						<configuration>
 							<passphrase>${gpg.passphrase}</passphrase>
 						</configuration>

--- a/src/test/java/edu/wpi/rail/jrosbridge/DummyServer.java
+++ b/src/test/java/edu/wpi/rail/jrosbridge/DummyServer.java
@@ -7,7 +7,7 @@ public class DummyServer {
 	private Server s;
 
 	public DummyServer(int port) {
-		this.s = new Server("localhost", port, "", DummyHandler.class);
+		this.s = new Server("localhost", port, "", null,DummyHandler.class);
 	}
 
 	public boolean start() {


### PR DESCRIPTION
Upgrade dependencies to be compatible with rosbridge_suite 0.11.4(&higher), fix websocket error.
[https://github.com/RobotWebTools/rosbridge_suite/issues/488](#488)