### PR TITLE
[Travis] jdk7 -> jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 
 jdk:
-  - openjdk7
-  - oraclejdk7
+  - openjdk11
+  - oraclejdk11
 
 branches:
   only:


### PR DESCRIPTION
PR #27 fails on Travis because jdk7 is not available. Picked 11 because it is currently the latest LTS.