### PR TITLE
Fix websocket handshake for ROS Noetic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>edu.wpi.rail</groupId>
 	<artifactId>jrosbridge</artifactId>
-	<version>0.2.2-SNAPSHOT</version>
+	<version>0.2.3</version>
 	
 	<properties>
 		<java.version>1.8</java.version>

--- a/src/main/java/edu/wpi/rail/jrosbridge/ClientConfigurator.java
+++ b/src/main/java/edu/wpi/rail/jrosbridge/ClientConfigurator.java
@@ -1,0 +1,21 @@
+package edu.wpi.rail.jrosbridge;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.ClientEndpointConfig;
+
+@ClientEndpoint
+public class ClientConfigurator extends ClientEndpointConfig.Configurator{
+
+  @Override
+  public void beforeRequest(Map<String, List<String>> headers) {
+    String origin = headers.get("Origin").get(0);
+    //headers.put("Origin", Arrays.asList("ws://"+origin));
+    
+    super.beforeRequest(headers);
+  }
+
+}

--- a/src/main/java/edu/wpi/rail/jrosbridge/ClientConfigurator.java
+++ b/src/main/java/edu/wpi/rail/jrosbridge/ClientConfigurator.java
@@ -1,6 +1,5 @@
 package edu.wpi.rail.jrosbridge;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/edu/wpi/rail/jrosbridge/ClientConfigurator.java
+++ b/src/main/java/edu/wpi/rail/jrosbridge/ClientConfigurator.java
@@ -11,9 +11,7 @@ public class ClientConfigurator extends ClientEndpointConfig.Configurator{
 
   @Override
   public void beforeRequest(Map<String, List<String>> headers) {
-    String origin = headers.get("Origin").get(0);
-    //headers.put("Origin", Arrays.asList("ws://"+origin));
-    
+
     super.beforeRequest(headers);
   }
 

--- a/src/main/java/edu/wpi/rail/jrosbridge/Ros.java
+++ b/src/main/java/edu/wpi/rail/jrosbridge/Ros.java
@@ -203,18 +203,8 @@ public class Ros {
 		try {
 			// create a WebSocket connection here
 			URI uri = new URI(this.getURL());
-//			ClientEndpointConfig.Builder configBuilder = ClientEndpointConfig.Builder.create();
-//			configBuilder.configurator(new ClientEndpointConfig.Configurator() {
-//			  @Override
-//			  public void beforeRequest(Map<String, List<String>> headers) {
-//			    String origin = headers.get("Origin").get(0);
-//			    headers.put("Origin", Arrays.asList("ws://"+origin));
-//			  }
-//			});
-//			ClientEndpointConfig clientConfig = configBuilder.build();
-			WebSocketContainer wsc = ContainerProvider.getWebSocketContainer();
-			
-			
+
+			WebSocketContainer wsc = ContainerProvider.getWebSocketContainer();		
 			wsc.connectToServer(this, uri);
 			
 			return true;

--- a/src/main/java/edu/wpi/rail/jrosbridge/Ros.java
+++ b/src/main/java/edu/wpi/rail/jrosbridge/Ros.java
@@ -21,6 +21,7 @@ import javax.websocket.OnError;
 import javax.websocket.OnMessage;
 import javax.websocket.OnOpen;
 import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
 
 import edu.wpi.rail.jrosbridge.callback.CallServiceCallback;
 import edu.wpi.rail.jrosbridge.services.ServiceRequest;
@@ -41,7 +42,8 @@ import edu.wpi.rail.jrosbridge.services.ServiceResponse;
  * @author Russell Toris - russell.toris@gmail.com
  * @version April 1, 2014
  */
-@ClientEndpoint
+@ClientEndpoint(
+    configurator = ClientConfigurator.class)
 public class Ros {
 
 	/**
@@ -201,8 +203,20 @@ public class Ros {
 		try {
 			// create a WebSocket connection here
 			URI uri = new URI(this.getURL());
-			ContainerProvider.getWebSocketContainer()
-					.connectToServer(this, uri);
+//			ClientEndpointConfig.Builder configBuilder = ClientEndpointConfig.Builder.create();
+//			configBuilder.configurator(new ClientEndpointConfig.Configurator() {
+//			  @Override
+//			  public void beforeRequest(Map<String, List<String>> headers) {
+//			    String origin = headers.get("Origin").get(0);
+//			    headers.put("Origin", Arrays.asList("ws://"+origin));
+//			  }
+//			});
+//			ClientEndpointConfig clientConfig = configBuilder.build();
+			WebSocketContainer wsc = ContainerProvider.getWebSocketContainer();
+			
+			
+			wsc.connectToServer(this, uri);
+			
 			return true;
 		} catch (DeploymentException | URISyntaxException | IOException e) {
 			// failed connection, return false
@@ -537,4 +551,5 @@ public class Ros {
 		// remove the callback
 		callServiceCallbacks.remove(serviceName);
 	}
+
 }


### PR DESCRIPTION
I added a ClientConfigurator implementation to the ClientEndpoint annotation of the Ros class.
This Configurator can modify the Http headers before sending or after receiving.
Even only adding this component made the "Origin" header compatible to rosbridge.